### PR TITLE
Fix encoding issue in rss.xml

### DIFF
--- a/rss.xml
+++ b/rss.xml
@@ -35,7 +35,7 @@
       <description>Farewell to a favorite.</description>
     </item>
     <item>
-      <title>Musing #668: Strunk & White and Williams</title>
+      <title>Musing #668: Strunk &amp; White and Williams</title>
       <link>https://www.cs.grinnell.edu/~rebelsky/musings/strunk-white-and-williams</link>
       <guid>https://www.cs.grinnell.edu/~rebelsky/musings/strunk-white-and-williams</guid>
       <pubDate>Fri, 29 Jun 2018 04:21:36 GMT</pubDate>


### PR DESCRIPTION
RSS is XML-based, so it requires escaping ampersands. See the [W3C RSS validator](https://validator.w3.org/feed/check.cgi?url=https%3A%2F%2Fwww.cs.grinnell.edu%2F~rebelsky%2Fmusings%2Frss.xml) for details.