### PR TITLE
Publish RSS feed when publishing

### DIFF
--- a/bin/publish
+++ b/bin/publish
@@ -6,4 +6,6 @@ echo "Synching images."
 time rsync -avz images rebelsky.cs.grinnell.edu:/home/rebelsky/public_html/musings
 echo "Synching css."
 time rsync -avz css rebelsky.cs.grinnell.edu:/home/rebelsky/public_html/musings
+echo "Synching rss."
+time rsync -avz rss.xml rebelsky.cs.grinnell.edu:/home/rebelsky/public_html/musings
 echo "Done"


### PR DESCRIPTION
The RSS feed file linked from the Musings homepage is 404, likely because the `publish` script never pushes it to the web server.